### PR TITLE
When searching/updating Patient resources, only look for those with active = true.

### DIFF
--- a/paintracker_daily_update_dawg_to_fhir_via_fume.py
+++ b/paintracker_daily_update_dawg_to_fhir_via_fume.py
@@ -82,7 +82,7 @@ for pat_row in pat_vals:
     # Check if patient already exists in FHIR store, update if found, insert if not
     fhir_query_response = None
     fhir_query_headers = {'Authorization': fhir_auth_token}
-    fhir_query_params = {'identifier': 'uwDAL_Clarity|' + str(pat_data['pat_id']) + ',http://www.uwmedicine.org/epic_patient_id|' + str(pat_data['pat_id'])}
+    fhir_query_params = {'identifier': 'uwDAL_Clarity|' + str(pat_data['pat_id']) + ',http://www.uwmedicine.org/epic_patient_id|' + str(pat_data['pat_id']), 'active': 'true'}
     fhir_query_response = session.get(fhir_endpoint + '/Patient', headers = fhir_query_headers, params = fhir_query_params)
 
     if debug_level > '8':


### PR DESCRIPTION
To handle duplicative Patient resources, we're using active = true to indicate that a Patient resource is the one go-to; there will be some that don't have this due to being deleted (active = false), or are artifacts from earlier work where we weren't using unique identifiers thoroughly (many of these don't have active set).
See also https://github.com/uwcirg/fhir-attrib-setter